### PR TITLE
[ERC681] replace query with functionParams

### DIFF
--- a/erc681/src/main/java/org/kethereum/erc681/ERC681.kt
+++ b/erc681/src/main/java/org/kethereum/erc681/ERC681.kt
@@ -7,7 +7,7 @@ data class ERC681(
         var prefix: String? = null,
         var address: String? = null,
         var function: String? = null,
-        var query: String = "",
+        var functionParams: Map<String, String> = mapOf(),
         var scheme: String? = null,
         var chainId: Long? = null,
 

--- a/erc681/src/main/java/org/kethereum/erc681/ERC681Generator.kt
+++ b/erc681/src/main/java/org/kethereum/erc681/ERC681Generator.kt
@@ -19,13 +19,15 @@ fun ERC681.generateURL(): String {
     }
 
     val paramList = mutableMapOf<String, String>()
+
+    paramList.putAll(functionParams)
+
     if (gas != null) {
         paramList.put("gas", gas.toString())
     }
     if (value != null) {
         paramList.put("value", value.toString())
     }
-
     if (paramList.isNotEmpty()) {
         res += "?" + paramList.map { it.key + "=" + it.value }.joinToString("&")
     }

--- a/erc681/src/main/java/org/kethereum/erc681/ERC681Parser.kt
+++ b/erc681/src/main/java/org/kethereum/erc681/ERC681Parser.kt
@@ -18,11 +18,13 @@ private enum class ParseState {
     QUERY
 }
 
-fun String.parseERC781() = ERC681().apply {
+fun String.toERC681() = ERC681().apply {
 
     var currentSegment = ""
 
     var currentState = SCHEMA
+
+    var query = ""
 
     fun stateTransition(newState: ParseState) {
         when (currentState) {
@@ -93,8 +95,9 @@ fun String.parseERC781() = ERC681().apply {
 
     gas = queryAsMap["gas"].toBigInteger()
     value = queryAsMap["value"].toBigInteger()
+    functionParams = queryAsMap.filter { it.key != "gas" && it.key != "value" }
 
     valid = valid && scheme == "ethereum"
 }
 
-fun parseERC681(url: String) = url.parseERC781()
+fun parseERC681(url: String) = url.toERC681()

--- a/erc681/src/test/java/org/kethereum/erc681/TheERC681Generator.kt
+++ b/erc681/src/test/java/org/kethereum/erc681/TheERC681Generator.kt
@@ -38,8 +38,9 @@ class TheERC681Generator {
 
     @Test
     fun toERC681Full() {
-        val highUsageERC681 = ERC681(address = "0x00AB42", prefix = "prefixFTW", chainId = 42, function = "funfun", value = BigInteger("100"))
-        assertThat(highUsageERC681.generateURL()).isEqualTo("ethereum:prefixFTW-0x00AB42@42/funfun?value=100")
-        assertThat(highUsageERC681.copy(prefix = null).generateURL()).isEqualTo("ethereum:0x00AB42@42/funfun?value=100")
+        val highUsageERC681 = ERC681(address = "0x00AB42", prefix = "prefixFTW", chainId = 42, function = "funfun", value = BigInteger("100"), gas= BigInteger("5"),
+                functionParams = mapOf("uint256" to "0", "address" to "0x0"))
+        assertThat(highUsageERC681.generateURL()).isEqualTo("ethereum:prefixFTW-0x00AB42@42/funfun?uint256=0&address=0x0&gas=5&value=100")
+        assertThat(highUsageERC681.copy(prefix = null).generateURL()).isEqualTo("ethereum:0x00AB42@42/funfun?uint256=0&address=0x0&gas=5&value=100")
     }
 }

--- a/erc681/src/test/java/org/kethereum/erc681/TheERC681Parsing.kt
+++ b/erc681/src/test/java/org/kethereum/erc681/TheERC681Parsing.kt
@@ -8,9 +8,15 @@ import java.math.BigInteger
 class TheERC681Parsing {
 
     @Test
-    fun weCanAccessQuery() {
-        Assertions.assertThat(parseERC681("ethereum:key-0x00AB42@23?value=42&gas=3&yay").query).isEqualTo("value=42&gas=3&yay")
+    fun weCanAccessFunctionParams() {
+        Assertions.assertThat(parseERC681("ethereum:key-0x00AB42@23?value=42&gas=3&yay").functionParams).isEqualTo(mapOf("yay" to "true"))
     }
+
+    @Test
+    fun weCanAccessFunctionParamsWithFunction() {
+        Assertions.assertThat(parseERC681("ethereum:key-0x00AB42@23/funfun?value=42&gas=3&yay").functionParams).isEqualTo(mapOf<String, String>("yay" to "true"))
+    }
+
 
     @Test
     fun weCanParseScientificNotationForValue() {
@@ -72,7 +78,7 @@ class TheERC681Parsing {
 
     @Test
     fun parsingERC681Works() {
-        Assertions.assertThat(parseERC681("ethereum:0x00AB42?value=1").query).isEqualTo("value=1")
+        Assertions.assertThat(parseERC681("ethereum:0x00AB42?value=1").functionParams).isEqualTo(mapOf<String, String>())
         Assertions.assertThat(parseERC681("ethereum:0x00AB42?value=1").address).isEqualTo("0x00AB42")
         Assertions.assertThat(parseERC681("ethereum:0x00AB42").value).isNull()
 


### PR DESCRIPTION
`query` is only a part of the string not of the semantics of ERC 681. Therefore `query` is replaced with a map `functionParams` that holds the parameters of the function call if any.

Validation of the type of the function parameters during parsing is not yet done.