### PR TITLE
add `BouncyCastleProvider()` on `Mnemonic` init

### DIFF
--- a/bip39/src/main/java/org/kethereum/bip39/Mnemonic.kt
+++ b/bip39/src/main/java/org/kethereum/bip39/Mnemonic.kt
@@ -5,12 +5,18 @@ import org.kethereum.bip32.generateKey
 import org.kethereum.extensions.toBitArray
 import org.kethereum.extensions.toByteArray
 import org.kethereum.hashes.sha256
+import org.spongycastle.jce.provider.BouncyCastleProvider
 import java.security.SecureRandom
+import java.security.Security
 import java.util.*
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.PBEKeySpec
 
 object Mnemonic {
+
+    init {
+        Security.insertProviderAt(BouncyCastleProvider(), 1)
+    }
 
     /**
      * Generates a seed buffer from a mnemonic phrase according to the BIP39 spec.


### PR DESCRIPTION
This PR fixes #20 

Normally this would not be noticeable in a project that already uses `Keys` from the `crypto` module, and it could be worked around by the user of the library by making sure to add BouncyCastleProvider before using the Mnemonic object but it should not be required.